### PR TITLE
Supprt paired read IDs ending with "/1" and "/2"

### DIFF
--- a/NGmerge.c
+++ b/NGmerge.c
@@ -147,10 +147,10 @@ void checkHeaders(char* head1, char* head2, char* header) {
       if (ok)
         break;
       for ( ; head1[j] != '\n' && head1[j] != '\0'
-        && head1[j] != ' '; j++) ;
+        && head1[j] != ' ' && head1[j] != '/'; j++) ;
       head1[j] = '\0';  // trim head1 for err msg
       exit(error(head1, ERRHEAD));
-    } else if (head1[j] == ' ')
+    } else if (head1[j] == ' ' || head1[j] == '/')
       ok = true;  // headers match
     header[j] = head1[j];
   }


### PR DESCRIPTION
An older FASTQ convention used "/1" and "/2" at the end of the read identifier for paired reads. This convention persists in reads downloaded from the NCBI Short Read Archive. It would be nice to be able to read these files directly, rather than having to rewrite the headers to replace the slash with a space.